### PR TITLE
Adding Dockerfile/Updating README as build option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,42 @@
+# NOTE: git commands below generated with GPT-4o
+# Use the official Rust image as the base image
+# See tag options: https://hub.docker.com/_/rust/
+FROM rust:1.85.0-slim-bookworm 
+
+# Install git (remove extra files after installation)
+RUN apt-get update && apt-get install -y git --no-install-recommends && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Set the working directory inside the container
+WORKDIR /app
+
+# Copy the project files into WORKDIR
+COPY . .
+
+# Following build steps here: https://github.com/koala-planner/HDDL-Parser?tab=readme-ov-file#build-instruction
+# 1. Met by base rust image above
+# 2. Add required parts of CreuSAT:
+#   - Clone the CreuSAT repository with minimal history and no file contents initially
+#   - Checkout a specific commit (CREUSAT_COMMIT) to prevent breaking changes
+#   - Configure sparse-checkout to only include the 'Robinson' directory to copy into WORKDIR
+#   - Clean-up unnecessary repo files
+
+# Checkout specific version to prevent breaking changes:
+ENV CREUSAT_COMMIT="b36aacd53874c49e77493ac6ecceabf0b1968154"
+RUN git clone --depth 1 --filter=blob:none --sparse https://github.com/sarsko/CreuSAT.git --branch master \
+    && cd CreuSAT \
+    && git reset --hard ${CREUSAT_COMMIT}\
+    && git sparse-checkout set Robinson \
+    && cp -r Robinson ../Robinson \
+    && cd .. \
+    && rm -rf CreuSAT
+
+# 3. Build the project in release mode
+#   The nightly build is required by build step (creusot-contracts-proc v0.2.0):
+#   Pin Specific nightly build to allow CreuSAT/Robinson to build:
+RUN rustup install nightly-2024-01-31 && rustup default nightly-2024-01-31
+
+# Build the project in release mode, clean-up any files after build:
+RUN cargo build --release
+
+# Set the entrypoint to the built executable
+ENTRYPOINT ["/app/target/release/hddl_analyzer"]

--- a/README.md
+++ b/README.md
@@ -13,12 +13,24 @@ In what follows, we provide the currently supported list of errors (for further 
 * **Unrefinable Tasks**: Flags compound tasks that do not have a primitive refinement.
 
 # Build Instruction
+
+## From Source:
 The following steps must be taken to compile the project. Wherever we mention "project_directory", we mean the root folder where the ```cargo.toml``` file is located.
 1. This project was written in the Rust programming language and requires its compiler (and cargo package manager) to be built.
 If you do not have it installed, follow the official installation guide ([link](https://www.rust-lang.org/tools/install)).
 2. The project depends on parts of [CreuSAT](https://github.com/sarsko/CreuSAT), a formally verified DPLL solver. In order to add this dependency, copy the ```Robinson``` directory from CreuSAT to the project_directory (i.e., you should have src, tests, and Robinson in the project_directory). This folder is automatically built with the rest of the project. However, this requires the nightly build of the Rust compiler. For instructions on how to switch to the nightly version, visit [here](https://rust-lang.github.io/rustup/concepts/channels.html).
 3. Open a terminal in the project_directory, and execute ```cargo build --release```.
 4. If all steps are done successfully, the executable file can be located in ```/project_directory/target/release/hddl_analyzer.exe```. Notice that in this step and subsequent ones where we refer to the ```hddl_analyzer.exe``` file, the ".exe" part might be something else based on your operating system.
+
+## Dockerfile:
+These commands must be executed from the top-level cloned project directory (i.e. `HDDL-Parser/`):
+1. `docker build -t hddl-parser:latest -f Dockerfile .`
+2. The dockerfile defines the entrypoint as the `hddl_analyzer` binary. You can run the binary on from your current directory like so:
+    ```bash
+    docker run -it -v $(pwd):/work --rm hddl-parser:latest \
+    verify /work/domain.hddl \
+    -p /work/problem.hddl
+    ```
 
 # Usage
 Once you have successfully built the project and obtained ```hddl_analyzer.exe```, you can execute the following commands. 


### PR DESCRIPTION
This commit adds a Dockerfile that builds `hddl_analyzer` and mounts it as the `ENTRYPOINT` for a container. It permits a simpler and isolated build process and then execution of the `hddl_analyzer` binary on files in a current working directory like so: 

```bash
 docker run -it -v $(pwd):/work --rm hddl-parser:latest \
    verify /work/domain.hddl \
    -p /work/problem.hddl
```

Feel free to not merge if you aren't interested but leaving here for other Docker users to find!